### PR TITLE
Customer specified endpoint

### DIFF
--- a/AppboyKit.js
+++ b/AppboyKit.js
@@ -233,11 +233,17 @@
                 options.sdkFlavor = 'mparticle';
                 options.enableHtmlInAppMessages = forwarderSettings.enableHtmlInAppMessages == 'True';
 
-                cluster = forwarderSettings.cluster || forwarderSettings.dataCenterLocation;
+                var cluster = forwarderSettings.cluster || forwarderSettings.dataCenterLocation;
+
                 if (clusterMapping.hasOwnProperty(cluster)) {
                     options.baseUrl = clusterMapping[cluster];
+                } else {
+                    var customUrl = decodeClusterSetting(cluster)
+                    if (customUrl) {
+                        options.baseUrl = customUrl;
+                    }
                 }
-
+                
                 if (testMode !== true) {
                     /* eslint-disable */
                     +function() {
@@ -303,6 +309,21 @@
         /** End mParticle API **/
         /**************************/
 
+        function decodeClusterSetting(clusterSetting) {
+            if (clusterSetting) {
+                var decodedSetting = clusterSetting.replace(/&amp;/g, '&');
+                decodedSetting = clusterSetting.replace(/&quot;/g, '"');
+                try {
+                    var clusterSettingObject = JSON.parse(decodedSetting)
+                    if (clusterSettingObject && clusterSettingObject.JS) {
+                        return 'https://' + clusterSettingObject.JS + '/api/v3';
+                    }
+                } catch (e) {
+                    console.log('Unable to configure custom Appboy cluster: ' + e.toString());
+                }
+            }
+        }
+
         function getSanitizedStringForAppboy(value) {
             if (typeof(value) === 'string') {
                 if (value.substr(0, 1) === '$') {
@@ -359,6 +380,7 @@
         this.setUserIdentity = setUserIdentity;
         this.setUserAttribute = setUserAttribute;
         this.removeUserAttribute = removeUserAttribute;
+        this.decodeClusterSetting = decodeClusterSetting;
     };
 
     if (!window || !window.mParticle || !window.mParticle.addForwarder) {

--- a/test/tests.js
+++ b/test/tests.js
@@ -696,4 +696,34 @@ describe('Appboy Forwarder', function () {
 
         window.appboy.baseUrl.should.equal('https://sdk.iad-03.appboy.com/api/v3');
     });
+
+    it('should use custom cluster url when passed cluster JSON', function(){
+        reportService.reset();
+        window.appboy = new MockAppboy();
+        mParticle.forwarder.init({
+            apiKey: '123456',
+            cluster: '{&quot;SDK&quot;:&quot;sdk.foo.bar.com&quot;,&quot;REST&quot;:&quot;rest.foo.bar.com&quot;,&quot;JS&quot;:&quot;js.foo.bar.com&quot;}'
+        }, reportService.cb, true, null, {
+            gender: 'm'
+        }, [{
+            Identity: 'testUser',
+            Type: IdentityType.CustomerId
+        }], '1.1', 'My App');
+
+        window.appboy.baseUrl.should.equal('https://js.foo.bar.com/api/v3');
+    });
+
+    it('decodeClusterSetting should return null when no setting given', function(){
+        Should(window.mParticle.forwarder.decodeClusterSetting()).not.be.ok();
+    });
+
+    it('decodeClusterSetting should return null on bad json', function(){
+        Should(window.mParticle.forwarder.decodeClusterSetting("blah&quote;")).not.be.ok();
+    });
+
+    it('decodeClusterSetting should return JS url when proper setting is given', function(){
+        var clusterSetting = "{&quot;SDK&quot;:&quot;sdk.foo.bar.com&quot;,&quot;REST&quot;:&quot;rest.foo.bar.com&quot;,&quot;JS&quot;:&quot;js.foo.bar.com&quot;}";
+        Should(window.mParticle.forwarder.decodeClusterSetting(clusterSetting)).equal('https://js.foo.bar.com/api/v3')
+    });
+
 });

--- a/test/tests.js
+++ b/test/tests.js
@@ -457,7 +457,7 @@ describe('Appboy Forwarder', function () {
         });
 
         window.appboy.should.have.property('logCustomEventCalled', true);
-        window.appboy.eventProperties[0].should.have.property('hostname', '');
+        window.appboy.eventProperties[0].should.have.property('hostname', window.location.hostname);
         window.appboy.eventProperties[0].should.have.property('title', 'Mocha Tests');
         window.appboy.eventProperties[0].should.have.property('attri$bute', 'what$ever');
     });


### PR DESCRIPTION
This updates the kit-integration to handle the `cluster` setting when it has been configured for a custom cluster.

At the moment, customer can select from a dropdown of preset clusters (01/02/EU/etc). The Appboy module is in the process of being updated such that the `cluster` setting may also return HTML-entity encoded JSON, for example:

```
{
   "settings":{
      "cluster":"{&quot;SDK&quot;:&quot;sdk.event.google.com&quot;,&quot;REST&quot;:&quot;rest.event.google.com&quot;,&quot;JS&quot;:&quot;js.event.google.com&quot;}",
      "apiKey":"foo",
      ...etc
   }
}
```

Customers will be able to configure a customer cluster host for the REST, JS and SDK endpoints. The JS-kit integration will now check for the preset clusters, and then attempt to parse the JSON. It will fall-back to not setting the baseUrl at all.