### PR TITLE
Push notifications

### DIFF
--- a/AppboyKit.js
+++ b/AppboyKit.js
@@ -200,6 +200,56 @@
             }
         }
 
+        function primeAppBoyWebPush() {
+            appboy.subscribeToNewInAppMessages(function(inAppMessages) {
+                var message = inAppMessages[0];
+                if (message != null) {
+                    var shouldDisplay;
+                    if (forwarderSettings.register_inapp == 'True') {
+                        shouldDisplay = true;
+                    } else {
+                        shouldDisplay = false;
+                    }
+
+                    if (message instanceof appboy.ab.InAppMessage) {
+                      // Read the key-value pair for msg-id
+                        var msgId = message.extras['msg-id'];
+
+                      // If this is our push primer message
+                        if (msgId == 'push-primer') {
+                          // We don't want to display the soft push prompt to users on browsers that don't support push, or if the user
+                          // has already granted/blocked permission
+                            if (!appboy.isPushSupported() || appboy.isPushPermissionGranted() || appboy.isPushBlocked()) {
+                                shouldDisplay = false;
+                            }
+                            if (message.buttons[0] != null) {
+                              // Prompt the user when the first button is clicked
+                                message.buttons[0].subscribeToClickedEvent(function() {
+                                    appboy.registerAppboyPushMessages();
+                                });
+                            }
+                        }
+                    }
+
+                  // Display the message
+                    if (shouldDisplay) {
+                        appboy.display.showInAppMessage(message);
+                    }
+                }
+
+              // Remove this message from the array of IAMs and return whatever's left
+                return inAppMessages.slice(1);
+            });
+        }
+
+        function openSession() {
+            appboy.openSession(function() {
+                if (forwarderSettings.safariWebsitePushId) {
+                    appboy.logCustomEvent('prime-for-push');
+                }
+            });
+        }
+
         function initForwarder(settings, service, testMode, trackerId, userAttributes, userIdentities, appVersion, appName) {  // eslint-disable-line no-unused-vars
             try {
                 forwarderSettings = settings;
@@ -209,6 +259,10 @@
                 options.sessionTimeoutInSeconds = forwarderSettings.ABKSessionTimeoutKey || 1800;
                 options.sdkFlavor = 'mparticle';
                 options.enableHtmlInAppMessages = forwarderSettings.enableHtmlInAppMessages == 'True';
+
+                if (forwarderSettings.safariWebsitePushId) {
+                    options.safariWebsitePushId = forwarderSettings.safariWebsitePushId;
+                }
 
                 var cluster = forwarderSettings.cluster || forwarderSettings.dataCenterLocation;
 
@@ -228,10 +282,10 @@
                         appboyQueue=[];
                         for (var s="initialize destroy getDeviceId toggleAppboyLogging setLogger openSession changeUser requestImmediateDataFlush requestFeedRefresh subscribeToFeedUpdates requestContentCardsRefresh subscribeToContentCardsUpdates logCardImpressions logCardClick logCardDismissal logFeedDisplayed logContentCardsDisplayed logInAppMessageImpression logInAppMessageClick logInAppMessageButtonClick logInAppMessageHtmlClick subscribeToNewInAppMessages removeSubscription removeAllSubscriptions logCustomEvent logPurchase isPushSupported isPushBlocked isPushGranted isPushPermissionGranted registerAppboyPushMessages unregisterAppboyPushMessages submitFeedback trackLocation stopWebTracking resumeWebTracking wipeData ab ab.User ab.User.Genders ab.User.NotificationSubscriptionTypes ab.User.prototype.getUserId ab.User.prototype.setFirstName ab.User.prototype.setLastName ab.User.prototype.setEmail ab.User.prototype.setGender ab.User.prototype.setDateOfBirth ab.User.prototype.setCountry ab.User.prototype.setHomeCity ab.User.prototype.setLanguage ab.User.prototype.setEmailNotificationSubscriptionType ab.User.prototype.setPushNotificationSubscriptionType ab.User.prototype.setPhoneNumber ab.User.prototype.setAvatarImageUrl ab.User.prototype.setLastKnownLocation ab.User.prototype.setUserAttribute ab.User.prototype.setCustomUserAttribute ab.User.prototype.addToCustomAttributeArray ab.User.prototype.removeFromCustomAttributeArray ab.User.prototype.incrementCustomUserAttribute ab.User.prototype.addAlias ab.InAppMessage ab.InAppMessage.SlideFrom ab.InAppMessage.ClickAction ab.InAppMessage.DismissType ab.InAppMessage.OpenTarget ab.InAppMessage.ImageStyle ab.InAppMessage.TextAlignment ab.InAppMessage.Orientation ab.InAppMessage.CropType ab.InAppMessage.prototype.subscribeToClickedEvent ab.InAppMessage.prototype.subscribeToDismissedEvent ab.InAppMessage.prototype.removeSubscription ab.InAppMessage.prototype.removeAllSubscriptions ab.InAppMessage.Button ab.InAppMessage.Button.prototype.subscribeToClickedEvent ab.InAppMessage.Button.prototype.removeSubscription ab.InAppMessage.Button.prototype.removeAllSubscriptions ab.SlideUpMessage ab.ModalMessage ab.FullScreenMessage ab.HtmlMessage ab.ControlMessage ab.Feed ab.Feed.prototype.getUnreadCardCount ab.ContentCards ab.ContentCards.prototype.getUnviewedCardCount ab.Card ab.ClassicCard ab.CaptionedImage ab.Banner ab.ControlCard ab.WindowUtils display display.automaticallyShowNewInAppMessages display.showInAppMessage display.showFeed display.destroyFeed display.toggleFeed display.showContentCards display.hideContentCards display.toggleContentCards sharedLib".split(" "),i=0;i<s.length;i++){for(var m=s[i],k=appboy,l=m.split("."), j=0; j < l.length-1; j++) k = k[l[j]]; k[l[j]]=(new Function("return function "+m.replace(/\./g,"_")+"(){appboyQueue.push(arguments); return true}"))()}
                         appboy.getUser = function() {
-                            return new appboy.ab.User
+                            return new appboy.ab.User;
                         };
                         appboy.getCachedFeed = function(){
-                            return new appboy.ab.Feed
+                            return new appboy.ab.Feed;
                         };
                         appboy.getCachedContentCards=function(){return new appboy.ab.ContentCards};(y=p.createElement(P)).type='text/javascript';
                         y.src='https://js.appboycdn.com/web-sdk/2.2/appboy.min.js';
@@ -240,11 +294,9 @@
                     }(window,document,'script');
                     appboy.initialize(forwarderSettings.apiKey, options);
 
-                    if (forwarderSettings.register_inapp == 'True') {
-                        appboy.display.automaticallyShowNewInAppMessages();
-                    }
+                    primeAppBoyWebPush();
+                    openSession();
 
-                    appboy.openSession();
                     appboy.requestInAppMessageRefresh();
                     /* eslint-enable */
                 }
@@ -252,11 +304,10 @@
                     if (!(appboy.initialize(forwarderSettings.apiKey, options))) {
                         return 'Failed to initialize: ' + name;
                     }
-                    if (forwarderSettings.register_inapp == 'True') {
-                        appboy.display.automaticallyShowNewInAppMessages();
-                    }
 
-                    appboy.openSession();
+                    primeAppBoyWebPush();
+                    openSession();
+
                     appboy.requestInAppMessageRefresh();
                 }
                 return 'Successfully initialized: ' + name;

--- a/AppboyKit.js
+++ b/AppboyKit.js
@@ -242,14 +242,6 @@
             });
         }
 
-        function openSession() {
-            appboy.openSession(function() {
-                if (forwarderSettings.safariWebsitePushId) {
-                    appboy.logCustomEvent('prime-for-push');
-                }
-            });
-        }
-
         function initForwarder(settings, service, testMode, trackerId, userAttributes, userIdentities, appVersion, appName) {  // eslint-disable-line no-unused-vars
             try {
                 forwarderSettings = settings;
@@ -295,7 +287,7 @@
                     appboy.initialize(forwarderSettings.apiKey, options);
 
                     primeAppBoyWebPush();
-                    openSession();
+                    appboy.openSession();
 
                     appboy.requestInAppMessageRefresh();
                     /* eslint-enable */
@@ -306,7 +298,7 @@
                     }
 
                     primeAppBoyWebPush();
-                    openSession();
+                    appboy.openSession();
 
                     appboy.requestInAppMessageRefresh();
                 }

--- a/AppboyKit.js
+++ b/AppboyKit.js
@@ -239,6 +239,14 @@
             });
         }
 
+        function openSession(forwarderSettings) {
+            appboy.openSession(function() {
+                if (forwarderSettings.softPushCustomEventName) {
+                    appboy.logCustomEvent(forwarderSettings.softPushCustomEventName);
+                }
+            });
+        }
+
         function initForwarder(settings, service, testMode, trackerId, userAttributes, userIdentities, appVersion, appName) {  // eslint-disable-line no-unused-vars
             try {
                 forwarderSettings = settings;
@@ -248,7 +256,6 @@
                 options.sessionTimeoutInSeconds = forwarderSettings.ABKSessionTimeoutKey || 1800;
                 options.sdkFlavor = 'mparticle';
                 options.enableHtmlInAppMessages = forwarderSettings.enableHtmlInAppMessages == 'True';
-                options.enableLogging = true;
 
                 if (forwarderSettings.safariWebsitePushId) {
                     options.safariWebsitePushId = forwarderSettings.safariWebsitePushId;
@@ -289,9 +296,8 @@
                     appboy.initialize(forwarderSettings.apiKey, options);
 
                     primeAppBoyWebPush();
-                    appboy.openSession();
+                    openSession(forwarderSettings);
 
-                    appboy.requestInAppMessageRefresh();
                     /* eslint-enable */
                 }
                 else {
@@ -300,8 +306,7 @@
                     }
 
                     primeAppBoyWebPush();
-                    appboy.openSession();
-                    appboy.requestInAppMessageRefresh();
+                    openSession(forwarderSettings);
                 }
                 return 'Successfully initialized: ' + name;
             }

--- a/AppboyKit.js
+++ b/AppboyKit.js
@@ -203,13 +203,9 @@
         function primeAppBoyWebPush() {
             appboy.subscribeToNewInAppMessages(function(inAppMessages) {
                 var message = inAppMessages[0];
+                var pushPrimer = false;
                 if (message != null) {
-                    var shouldDisplay;
-                    if (forwarderSettings.register_inapp == 'True') {
-                        shouldDisplay = true;
-                    } else {
-                        shouldDisplay = false;
-                    }
+                    shouldDisplay = true;
 
                     if (message instanceof appboy.ab.InAppMessage) {
                       // Read the key-value pair for msg-id
@@ -217,6 +213,7 @@
 
                       // If this is our push primer message
                         if (msgId == 'push-primer') {
+                            pushPrimer = true;
                           // We don't want to display the soft push prompt to users on browsers that don't support push, or if the user
                           // has already granted/blocked permission
                             if (!appboy.isPushSupported() || appboy.isPushPermissionGranted() || appboy.isPushBlocked()) {
@@ -231,8 +228,8 @@
                         }
                     }
 
-                  // Display the message
-                    if (shouldDisplay) {
+                    // Display the message if it's a push primer message and shouldDisplay is true
+                    if ((pushPrimer && shouldDisplay) || (!pushPrimer && forwarderSettings.register_inapp === 'True')) {
                         appboy.display.showInAppMessage(message);
                     }
                 }
@@ -251,9 +248,14 @@
                 options.sessionTimeoutInSeconds = forwarderSettings.ABKSessionTimeoutKey || 1800;
                 options.sdkFlavor = 'mparticle';
                 options.enableHtmlInAppMessages = forwarderSettings.enableHtmlInAppMessages == 'True';
+                options.enableLogging = true;
 
                 if (forwarderSettings.safariWebsitePushId) {
                     options.safariWebsitePushId = forwarderSettings.safariWebsitePushId;
+                }
+
+                if (forwarderSettings.serviceWorkerLocation) {
+                    options.serviceWorkerLocation = forwarderSettings.serviceWorkerLocation;
                 }
 
                 var cluster = forwarderSettings.cluster || forwarderSettings.dataCenterLocation;
@@ -299,7 +301,6 @@
 
                     primeAppBoyWebPush();
                     appboy.openSession();
-
                     appboy.requestInAppMessageRefresh();
                 }
                 return 'Successfully initialized: ' + name;

--- a/test/tests.js
+++ b/test/tests.js
@@ -174,9 +174,8 @@ describe('Appboy Forwarder', function () {
                 return true;
             };
 
-            this.openSession = function(func) {
+            this.openSession = function() {
                 self.openSessionCalled = true;
-                func();
             };
 
             this.requestInAppMessageRefresh = function (){
@@ -725,24 +724,5 @@ describe('Appboy Forwarder', function () {
     it('decodeClusterSetting should return JS url when proper setting is given', function(){
         var clusterSetting = '{&quot;SDK&quot;:&quot;sdk.foo.bar.com&quot;,&quot;REST&quot;:&quot;rest.foo.bar.com&quot;,&quot;JS&quot;:&quot;js.foo.bar.com&quot;}';
         Should(window.mParticle.forwarder.decodeClusterSetting(clusterSetting)).equal('https://js.foo.bar.com/api/v3');
-    });
-
-    it('does not log prime-for-push when initialized without safariWebsitePushId', function() {
-        Should(window.appboy.logCustomEventName).not.be.ok();
-    });
-
-    it('logs prime-for-push when initialized with safariWebsitePushId', function() {
-        mParticle.forwarder.init({
-            apiKey: '123456',
-            safariWebsitePushId: 'test'
-        }, reportService.cb, true, null, {
-            gender: 'm'
-        }, [{
-            Identity: 'testUser',
-            Type: IdentityType.CustomerId
-        }], '1.1', 'My App');
-
-        window.appboy.logCustomEventCalled.should.equal(true);
-        window.appboy.logCustomEventName.should.equal('prime-for-push');
     });
 });

--- a/test/tests.js
+++ b/test/tests.js
@@ -174,12 +174,9 @@ describe('Appboy Forwarder', function () {
                 return true;
             };
 
-            this.openSession = function() {
+            this.openSession = function(func) {
                 self.openSessionCalled = true;
-            };
-
-            this.requestInAppMessageRefresh = function (){
-                self.inAppMessageRefreshCalled = true;
+                func();
             };
 
             this.changeUser = function(id){
@@ -261,7 +258,6 @@ describe('Appboy Forwarder', function () {
     it('should open a new session and refresh in app messages upon initialization', function(){
         window.appboy.should.have.property('initializeCalled', true);
         window.appboy.should.have.property('openSessionCalled', true);
-        window.appboy.should.have.property('inAppMessageRefreshCalled', true);
         window.appboy.should.have.property('subscribeToNewInAppMessagesCalled', true);
         window.appboy.display.should.have.property('automaticallyShowNewInAppMessagesCalled', false);
     });
@@ -724,5 +720,23 @@ describe('Appboy Forwarder', function () {
     it('decodeClusterSetting should return JS url when proper setting is given', function(){
         var clusterSetting = '{&quot;SDK&quot;:&quot;sdk.foo.bar.com&quot;,&quot;REST&quot;:&quot;rest.foo.bar.com&quot;,&quot;JS&quot;:&quot;js.foo.bar.com&quot;}';
         Should(window.mParticle.forwarder.decodeClusterSetting(clusterSetting)).equal('https://js.foo.bar.com/api/v3');
+    });
+
+    it('does not log prime-for-push when initialized without softPushCustomEventName', function() {
+        Should(window.appboy.logCustomEventName).not.be.ok();
+    });
+
+    it('logs soft push custom event when initialized with softPushCustomEventName', function() {
+        mParticle.forwarder.init({
+            apiKey: '123456',
+            softPushCustomEventName: 'prime-for-push'
+        }, reportService.cb, true, null, {
+            gender: 'm'
+        }, [{
+            Identity: 'testUser',
+            Type: IdentityType.CustomerId
+        }], '1.1', 'My App');
+        window.appboy.logCustomEventCalled.should.equal(true);
+        window.appboy.logCustomEventName.should.equal('prime-for-push');
     });
 });


### PR DESCRIPTION
This PR enables push notifications in MP's Braze SDK integration. I implemented a "soft push" as well, per Braze [best practices for soft push prompts](https://www.braze.com/documentation/Web/#soft-push-prompts) before the actual push notification request comes in.

A customer will follow along with the above instructions to set up a campaign, but can label the event whatever they want (not necessarily prime-for-push). Then in their app, they can call mParticle.logEvent('nameOfPushPrimerEvent') to activate.