### PR TITLE
Bugfix - Refactor reportEvent

### DIFF
--- a/AppboyKit.js
+++ b/AppboyKit.js
@@ -334,7 +334,8 @@ window.appboy = require('appboy-web-sdk');
 
             sanitizedEventName = getSanitizedValueForAppboy(window.location.pathname);
             sanitizedAttrs = getSanitizedCustomProperties(attrs);
-            appboy.logCustomEvent(sanitizedEventName, sanitizedAttrs);
+            var result = appboy.logCustomEvent(sanitizedEventName, sanitizedAttrs);
+            return result;
         }
 
         function setDefaultAttribute(key, value) {
@@ -372,9 +373,7 @@ window.appboy = require('appboy-web-sdk');
             }
 
             var reportEvent = appboy.logCustomEvent(sanitizedEventName, sanitizedProperties);
-            if (reportEvent && reportingService) {
-                reportingService(self, event);
-            }
+            return reportEvent;
         }
 
         /**************************/
@@ -385,12 +384,7 @@ window.appboy = require('appboy-web-sdk');
 
             if (event.EventDataType == MessageType.Commerce && event.EventCategory == mParticle.CommerceEventType.ProductPurchase) {
                 reportEvent = logPurchaseEvent(event);
-                if (reportEvent && reportingService) {
-                    reportingService(self, event);
-                }
-                return;
-            }
-            if (event.EventDataType == MessageType.Commerce) {
+            } else if (event.EventDataType == MessageType.Commerce) {
                 var listOfPageEvents = mParticle.eCommerce.expandCommerceEvent(event);
                 if (listOfPageEvents != null) {
                     for (var i = 0; i < listOfPageEvents.length; i++) {
@@ -402,16 +396,20 @@ window.appboy = require('appboy-web-sdk');
                         }
                     }
                 }
+                reportEvent = true;
             } else if (event.EventDataType == MessageType.PageEvent) {
-                logAppboyEvent(event);
+                reportEvent = logAppboyEvent(event);
             } else if (event.EventDataType == MessageType.PageView) {
                 if (forwarderSettings.forwardScreenViews == 'True') {
-                    logAppboyPageViewEvent(event);
+                    reportEvent = logAppboyPageViewEvent(event);
                 }
             }
-            else
-            {
+            else {
                 return 'Can\'t send event type to forwarder ' + name + ', event type is not supported';
+            }
+
+            if (reportEvent && reportingService) {
+                reportingService(self, event);
             }
         }
 

--- a/AppboyKit.js
+++ b/AppboyKit.js
@@ -316,12 +316,10 @@ window.appboy = require('appboy-web-sdk');
                         return 'Properties did not pass validation for ' + sanitizedProductName;
                     }
 
-                    if (appboy.logPurchase(sanitizedProductName, parseFloat(product.Price), event.CurrencyCode, product.Quantity, sanitizedProperties)) {
-                        reportEvent = true;
-                    }
+                    reportEvent = appboy.logPurchase(sanitizedProductName, parseFloat(product.Price), event.CurrencyCode, product.Quantity, sanitizedProperties);
                 });
             }
-            return reportEvent;
+            return reportEvent === true;
         }
 
         function logAppboyPageViewEvent(event) {
@@ -334,8 +332,8 @@ window.appboy = require('appboy-web-sdk');
 
             sanitizedEventName = getSanitizedValueForAppboy(window.location.pathname);
             sanitizedAttrs = getSanitizedCustomProperties(attrs);
-            var result = appboy.logCustomEvent(sanitizedEventName, sanitizedAttrs);
-            return result;
+            var reportEvent = appboy.logCustomEvent(sanitizedEventName, sanitizedAttrs);
+            return reportEvent === true;
         }
 
         function setDefaultAttribute(key, value) {
@@ -373,7 +371,7 @@ window.appboy = require('appboy-web-sdk');
             }
 
             var reportEvent = appboy.logCustomEvent(sanitizedEventName, sanitizedProperties);
-            return reportEvent;
+            return reportEvent === true;
         }
 
         /**************************/
@@ -389,14 +387,13 @@ window.appboy = require('appboy-web-sdk');
                 if (listOfPageEvents != null) {
                     for (var i = 0; i < listOfPageEvents.length; i++) {
                         try {
-                            logAppboyEvent(listOfPageEvents[i]);
+                            reportEvent = logAppboyEvent(listOfPageEvents[i]);
                         }
                         catch (err) {
                             return 'Error logging page event' + err.message;
                         }
                     }
                 }
-                reportEvent = true;
             } else if (event.EventDataType == MessageType.PageEvent) {
                 reportEvent = logAppboyEvent(event);
             } else if (event.EventDataType == MessageType.PageView) {

--- a/AppboyKit.js
+++ b/AppboyKit.js
@@ -386,13 +386,19 @@ window.appboy = require('appboy-web-sdk');
                 var listOfPageEvents = mParticle.eCommerce.expandCommerceEvent(event);
                 if (listOfPageEvents != null) {
                     for (var i = 0; i < listOfPageEvents.length; i++) {
+                        // finalLoopResult keeps track of if any logAppBoyEvent in this loop returns true or not
+                        var finalLoopResult = false;
                         try {
                             reportEvent = logAppboyEvent(listOfPageEvents[i]);
+                            if (reportEvent === true) {
+                                finalLoopResult = true;
+                            }
                         }
                         catch (err) {
                             return 'Error logging page event' + err.message;
                         }
                     }
+                    reportEvent = finalLoopResult === true;
                 }
             } else if (event.EventDataType == MessageType.PageEvent) {
                 reportEvent = logAppboyEvent(event);
@@ -405,7 +411,7 @@ window.appboy = require('appboy-web-sdk');
                 return 'Can\'t send event type to forwarder ' + name + ', event type is not supported';
             }
 
-            if (reportEvent && reportingService) {
+            if (reportEvent === true && reportingService) {
                 reportingService(self, event);
             }
         }

--- a/src/AppboyKit-dev.js
+++ b/src/AppboyKit-dev.js
@@ -66,12 +66,10 @@ window.appboy = require('appboy-web-sdk');
                         return 'Properties did not pass validation for ' + sanitizedProductName;
                     }
 
-                    if (appboy.logPurchase(sanitizedProductName, parseFloat(product.Price), event.CurrencyCode, product.Quantity, sanitizedProperties)) {
-                        reportEvent = true;
-                    }
+                    reportEvent = appboy.logPurchase(sanitizedProductName, parseFloat(product.Price), event.CurrencyCode, product.Quantity, sanitizedProperties);
                 });
             }
-            return reportEvent;
+            return reportEvent === true;
         }
 
         function logAppboyPageViewEvent(event) {
@@ -84,8 +82,8 @@ window.appboy = require('appboy-web-sdk');
 
             sanitizedEventName = getSanitizedValueForAppboy(window.location.pathname);
             sanitizedAttrs = getSanitizedCustomProperties(attrs);
-            var result = appboy.logCustomEvent(sanitizedEventName, sanitizedAttrs);
-            return result;
+            var reportEvent = appboy.logCustomEvent(sanitizedEventName, sanitizedAttrs);
+            return reportEvent === true;
         }
 
         function setDefaultAttribute(key, value) {
@@ -123,7 +121,7 @@ window.appboy = require('appboy-web-sdk');
             }
 
             var reportEvent = appboy.logCustomEvent(sanitizedEventName, sanitizedProperties);
-            return reportEvent;
+            return reportEvent === true;
         }
 
         /**************************/
@@ -139,14 +137,13 @@ window.appboy = require('appboy-web-sdk');
                 if (listOfPageEvents != null) {
                     for (var i = 0; i < listOfPageEvents.length; i++) {
                         try {
-                            logAppboyEvent(listOfPageEvents[i]);
+                            reportEvent = logAppboyEvent(listOfPageEvents[i]);
                         }
                         catch (err) {
                             return 'Error logging page event' + err.message;
                         }
                     }
                 }
-                reportEvent = true;
             } else if (event.EventDataType == MessageType.PageEvent) {
                 reportEvent = logAppboyEvent(event);
             } else if (event.EventDataType == MessageType.PageView) {

--- a/src/AppboyKit-dev.js
+++ b/src/AppboyKit-dev.js
@@ -136,13 +136,19 @@ window.appboy = require('appboy-web-sdk');
                 var listOfPageEvents = mParticle.eCommerce.expandCommerceEvent(event);
                 if (listOfPageEvents != null) {
                     for (var i = 0; i < listOfPageEvents.length; i++) {
+                        // finalLoopResult keeps track of if any logAppBoyEvent in this loop returns true or not
+                        var finalLoopResult = false;
                         try {
                             reportEvent = logAppboyEvent(listOfPageEvents[i]);
+                            if (reportEvent === true) {
+                                finalLoopResult = true;
+                            }
                         }
                         catch (err) {
                             return 'Error logging page event' + err.message;
                         }
                     }
+                    reportEvent = finalLoopResult === true;
                 }
             } else if (event.EventDataType == MessageType.PageEvent) {
                 reportEvent = logAppboyEvent(event);
@@ -155,7 +161,7 @@ window.appboy = require('appboy-web-sdk');
                 return 'Can\'t send event type to forwarder ' + name + ', event type is not supported';
             }
 
-            if (reportEvent && reportingService) {
+            if (reportEvent === true && reportingService) {
                 reportingService(self, event);
             }
         }

--- a/src/AppboyKit-dev.js
+++ b/src/AppboyKit-dev.js
@@ -84,7 +84,8 @@ window.appboy = require('appboy-web-sdk');
 
             sanitizedEventName = getSanitizedValueForAppboy(window.location.pathname);
             sanitizedAttrs = getSanitizedCustomProperties(attrs);
-            appboy.logCustomEvent(sanitizedEventName, sanitizedAttrs);
+            var result = appboy.logCustomEvent(sanitizedEventName, sanitizedAttrs);
+            return result;
         }
 
         function setDefaultAttribute(key, value) {
@@ -122,9 +123,7 @@ window.appboy = require('appboy-web-sdk');
             }
 
             var reportEvent = appboy.logCustomEvent(sanitizedEventName, sanitizedProperties);
-            if (reportEvent && reportingService) {
-                reportingService(self, event);
-            }
+            return reportEvent;
         }
 
         /**************************/
@@ -135,12 +134,7 @@ window.appboy = require('appboy-web-sdk');
 
             if (event.EventDataType == MessageType.Commerce && event.EventCategory == mParticle.CommerceEventType.ProductPurchase) {
                 reportEvent = logPurchaseEvent(event);
-                if (reportEvent && reportingService) {
-                    reportingService(self, event);
-                }
-                return;
-            }
-            if (event.EventDataType == MessageType.Commerce) {
+            } else if (event.EventDataType == MessageType.Commerce) {
                 var listOfPageEvents = mParticle.eCommerce.expandCommerceEvent(event);
                 if (listOfPageEvents != null) {
                     for (var i = 0; i < listOfPageEvents.length; i++) {
@@ -152,16 +146,20 @@ window.appboy = require('appboy-web-sdk');
                         }
                     }
                 }
+                reportEvent = true;
             } else if (event.EventDataType == MessageType.PageEvent) {
-                logAppboyEvent(event);
+                reportEvent = logAppboyEvent(event);
             } else if (event.EventDataType == MessageType.PageView) {
                 if (forwarderSettings.forwardScreenViews == 'True') {
-                    logAppboyPageViewEvent(event);
+                    reportEvent = logAppboyPageViewEvent(event);
                 }
             }
-            else
-            {
+            else {
                 return 'Can\'t send event type to forwarder ' + name + ', event type is not supported';
+            }
+
+            if (reportEvent && reportingService) {
+                reportingService(self, event);
             }
         }
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -271,15 +271,8 @@ describe('Appboy Forwarder', function () {
         });
         window.appboy.should.have.property('logCustomEventCalled', true);
         window.appboy.should.have.property('logCustomEventName', 'Test Event');
-    });
 
-    it('should call reportService when logging event', function () {
-        mParticle.forwarder.process({
-            EventName: 'Test Reporting Event',
-            EventDataType: MessageType.PageEvent
-        });
-
-        reportService.event.should.have.property('EventName', 'Test Reporting Event');
+        reportService.event.should.have.property('EventName', 'Test Event');
     });
 
     it('should log an event with properties', function(){
@@ -348,6 +341,7 @@ describe('Appboy Forwarder', function () {
         window.appboy.purchaseEventProperties[0][2].should.equal(1);
         window.appboy.purchaseEventProperties[0][3]['attribute'].should.equal('whatever');
         window.appboy.purchaseEventProperties[0][3]['Sku'].should.equal(12345);
+        reportService.event.should.have.property('EventName', 'Test Purchase Event');
     });
 
     it('should log a purchase event without attributes', function(){
@@ -410,11 +404,14 @@ describe('Appboy Forwarder', function () {
 
     it('should log a custom event for non-purchase commerce events', function(){
         mParticle.forwarder.process({
-            EventName: 'Test Purchase Event',
+            EventName: 'Test Non-Purchase Event',
             EventDataType: MessageType.Commerce,
             EventCategory: EventType.Other
         });
+
         window.appboy.should.have.property('logCustomEventCalled', true);
+        reportService.event.should.have.property('EventName', 'Test Non-Purchase Event');
+
     });
 
     it('should log a page view when forwardScreenViews is true, and not log when forwarder setting is false', function(){
@@ -458,6 +455,7 @@ describe('Appboy Forwarder', function () {
         window.appboy.eventProperties[0].should.have.property('hostname', window.location.hostname);
         window.appboy.eventProperties[0].should.have.property('title', 'Mocha Tests');
         window.appboy.eventProperties[0].should.have.property('attri$bute', 'what$ever');
+        reportService.event.should.have.property('EventName', 'Test Log Page View');
     });
 
     it('should sanitize purchase event and properties', function(){


### PR DESCRIPTION
mParticle expects a single forwarded event per mParticle event. Sometimes a kit expands a single event into several (eCommerce), which modifies the event name and affects forwarding stats in the mParticle UI. This PR resolves this to only send one forwarding event per mParticle event, regardless of if the event is expanded and multiple events are sent to AppBoy.