### PR TITLE
Refactor variables

### DIFF
--- a/AppboyKit.js
+++ b/AppboyKit.js
@@ -493,7 +493,7 @@ var mpAppboyKit = (function (exports) {
 	                var message = inAppMessages[0];
 	                var pushPrimer = false;
 	                if (message != null) {
-	                    shouldDisplay = true;
+	                    var shouldDisplay = true;
 
 	                    if (message instanceof appboy.ab.InAppMessage) {
 	                        // Read the key-value pair for msg-id
@@ -539,7 +539,6 @@ var mpAppboyKit = (function (exports) {
 	            try {
 	                forwarderSettings = settings;
 	                reportingService = service;
-	                isTesting = testMode;
 	                // 30 min is Appboy default
 	                options.sessionTimeoutInSeconds = forwarderSettings.ABKSessionTimeoutKey || 1800;
 	                options.sdkFlavor = 'mparticle';

--- a/dist/AppboyKit.common.js
+++ b/dist/AppboyKit.common.js
@@ -504,7 +504,7 @@ window.appboy = appboy_min;
                 var message = inAppMessages[0];
                 var pushPrimer = false;
                 if (message != null) {
-                    shouldDisplay = true;
+                    var shouldDisplay = true;
 
                     if (message instanceof appboy.ab.InAppMessage) {
                         // Read the key-value pair for msg-id
@@ -550,7 +550,6 @@ window.appboy = appboy_min;
             try {
                 forwarderSettings = settings;
                 reportingService = service;
-                isTesting = testMode;
                 // 30 min is Appboy default
                 options.sessionTimeoutInSeconds = forwarderSettings.ABKSessionTimeoutKey || 1800;
                 options.sdkFlavor = 'mparticle';

--- a/dist/AppboyKit.iife.js
+++ b/dist/AppboyKit.iife.js
@@ -503,7 +503,7 @@ var mpAppboyKit = (function (exports) {
 	                var message = inAppMessages[0];
 	                var pushPrimer = false;
 	                if (message != null) {
-	                    shouldDisplay = true;
+	                    var shouldDisplay = true;
 
 	                    if (message instanceof appboy.ab.InAppMessage) {
 	                        // Read the key-value pair for msg-id
@@ -549,7 +549,6 @@ var mpAppboyKit = (function (exports) {
 	            try {
 	                forwarderSettings = settings;
 	                reportingService = service;
-	                isTesting = testMode;
 	                // 30 min is Appboy default
 	                options.sessionTimeoutInSeconds = forwarderSettings.ABKSessionTimeoutKey || 1800;
 	                options.sdkFlavor = 'mparticle';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mparticle/web-appboy-kit",
-  "version": "2.0.0-rc.3",
+  "version": "2.0.0-rc.4",
   "author": "mParticle Developers <developers@mparticle.com> (https://www.mparticle.com)",
   "description": "mParticle integration sdk for Appboy",
   "browser": "dist/AppboyKit.common.js",

--- a/src/AppboyKit-dev.js
+++ b/src/AppboyKit-dev.js
@@ -223,7 +223,7 @@ var isobject = require('isobject');
                 var message = inAppMessages[0];
                 var pushPrimer = false;
                 if (message != null) {
-                    shouldDisplay = true;
+                    var shouldDisplay = true;
 
                     if (message instanceof appboy.ab.InAppMessage) {
                         // Read the key-value pair for msg-id
@@ -269,7 +269,6 @@ var isobject = require('isobject');
             try {
                 forwarderSettings = settings;
                 reportingService = service;
-                isTesting = testMode;
                 // 30 min is Appboy default
                 options.sessionTimeoutInSeconds = forwarderSettings.ABKSessionTimeoutKey || 1800;
                 options.sdkFlavor = 'mparticle';


### PR DESCRIPTION
These variables without a declarative `var` globals are considered undefined in a strict mode app when inside an app built with rollup. This change fixes that.