### PR TITLE
Bugfix - Respect userId choice in mParticle UI dropdown 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+## Releases
+
+--
+
+#### 2.0.1 - 2019-12-03
+
+-   Bugfix - Respect userId choice in mParticle UI dropdown
+-   Add version number
+-   Remove isObject dependency

--- a/dist/AppboyKit.iife.js
+++ b/dist/AppboyKit.iife.js
@@ -7,10 +7,6 @@ var mpAppboyKit = (function (exports) {
 		return module = { exports: {} }, fn(module, module.exports), module.exports;
 	}
 
-	function getCjsExportFromNamespace (n) {
-		return n && n['default'] || n;
-	}
-
 	var appboy_min = createCommonjsModule(function (module, exports) {
 	/*
 	* Braze Web SDK v2.2.4
@@ -261,26 +257,8 @@ var mpAppboyKit = (function (exports) {
 	aa=T=null!=ca?ca.apply():new T.constructor;else T=T[R[U]];ba+="."+R[U];}null!=T&&"function"===typeof T&&T.apply(aa,O[P]);}}}}).call(window);
 	});
 
-	/*!
-	 * isobject <https://github.com/jonschlinkert/isobject>
-	 *
-	 * Copyright (c) 2014-2017, Jon Schlinkert.
-	 * Released under the MIT License.
-	 */
-
-	function isObject(val) {
-	  return val != null && typeof val === 'object' && Array.isArray(val) === false;
-	}
-
-	var isobject = /*#__PURE__*/Object.freeze({
-		'default': isObject
-	});
-
-	var isobject$1 = getCjsExportFromNamespace(isobject);
-
 	/* eslint-disable no-undef */
 	window.appboy = appboy_min;
-
 	//  Copyright 2015 mParticle, Inc.
 	//
 	//  Licensed under the Apache License, Version 2.0 (the "License");
@@ -297,6 +275,7 @@ var mpAppboyKit = (function (exports) {
 
 	    var name = 'Appboy',
 	        moduleId = 28,
+	        version = '2.0.1',
 	        MessageType = {
 	            PageView: 3,
 	            PageEvent: 4,
@@ -487,14 +466,34 @@ var mpAppboyKit = (function (exports) {
 	        }
 
 	        function setUserIdentity(id, type) {
-	            if (type == window.mParticle.IdentityType.CustomerId) {
-	                appboy.changeUser(id);
+	            // Only use this method when mParicle core SDK is version 1
+	            // Other versions use onUserIdentified, which is called after setUserIdentity from core SDK
+	            if (window.mParticle.getVersion().split('.')[0] === '1') {
+	                if (type == window.mParticle.IdentityType.CustomerId) {
+	                    appboy.changeUser(id);
+	                } else if (type == window.mParticle.IdentityType.Email) {
+	                    appboy.getUser().setEmail(id);
+	                } else {
+	                    return ("Can't call setUserIdentity on forwarder " + name + ', identity type not supported.');
+	                }
 	            }
-	            else if (type == window.mParticle.IdentityType.Email) {
-	                appboy.getUser().setEmail(id);
+	        }
+
+	        // onUserIdentified is not used in version 1 so there is no need to check for version number
+	        function onUserIdentified(user) {
+	            var appboyUserIDType,
+	                userIdentities = user.getUserIdentities().userIdentities;
+
+	            if (forwarderSettings.userIdentificationType === 'MPID') {
+	                appboyUserIDType = user.getMPID();
+	            } else {
+	                appboyUserIDType = userIdentities[forwarderSettings.userIdentificationType.toLowerCase()];
 	            }
-	            else {
-	                return 'Can\'t call setUserIdentity on forwarder ' + name + ', identity type not supported.';
+
+	            appboy.changeUser(appboyUserIDType);
+
+	            if (userIdentities.email) {
+	                appboy.getUser().setEmail(userIdentities.email);
 	            }
 	        }
 
@@ -671,6 +670,7 @@ var mpAppboyKit = (function (exports) {
 	        this.process = processEvent;
 	        this.setUserIdentity = setUserIdentity;
 	        this.setUserAttribute = setUserAttribute;
+	        this.onUserIdentified = onUserIdentified;
 	        this.removeUserAttribute = removeUserAttribute;
 	        this.decodeClusterSetting = decodeClusterSetting;
 	    };
@@ -685,12 +685,12 @@ var mpAppboyKit = (function (exports) {
 	            return;
 	        }
 
-	        if (!isobject$1(config)) {
+	        if (!isObject(config)) {
 	            window.console.log('\'config\' must be an object. You passed in a ' + typeof config);
 	            return;
 	        }
 
-	        if (isobject$1(config.kits)) {
+	        if (isObject(config.kits)) {
 	            config.kits[name] = {
 	                constructor: constructor
 	            };
@@ -711,12 +711,21 @@ var mpAppboyKit = (function (exports) {
 	        });
 	    }
 
+	    function isObject(val) {
+	        return (val != null && typeof val === 'object' && Array.isArray(val) === false);
+	    }
+
 	    var AppboyKitDev = {
-	        register: register
+	        register: register,
+	        getVersion: function() {
+	            return version;
+	        }
 	    };
 	var AppboyKitDev_1 = AppboyKitDev.register;
+	var AppboyKitDev_2 = AppboyKitDev.getVersion;
 
 	exports.default = AppboyKitDev;
+	exports.getVersion = AppboyKitDev_2;
 	exports.register = AppboyKitDev_1;
 
 	return exports;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mparticle/web-appboy-kit",
-  "version": "2.0.0-rc.3",
+  "version": "2.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -116,11 +116,6 @@
       "requires": {
         "@types/estree": "0.0.39"
       }
-    },
-    "isobject": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
-      "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA=="
     },
     "jade": {
       "version": "0.26.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mparticle/web-appboy-kit",
-  "version": "2.0.0-rc.4",
+  "version": "2.0.1",
   "author": "mParticle Developers <developers@mparticle.com> (https://www.mparticle.com)",
   "description": "mParticle integration sdk for Appboy",
   "browser": "dist/AppboyKit.common.js",
@@ -20,7 +20,6 @@
     "should": "^7.1.0"
   },
   "dependencies": {
-    "isobject": "^4.0.0",
     "@mparticle/web-sdk": "^2.9.4-rc.1",
     "appboy-web-sdk": "2.2.4"
   },


### PR DESCRIPTION
When this was built, we did not offer an external id UI dropdown. Now that we do we need to respect the chosen id type.

I also removed isobject to avoid having dependencies, and added a changelog, as well as a public API for getVersion.