### PR TITLE
feat: add new Braze clusters

### DIFF
--- a/src/AppboyKit-dev.js
+++ b/src/AppboyKit-dev.js
@@ -28,9 +28,11 @@ var clusterMapping = {
     '02': 'sdk.iad-02.braze.com',
     '03': 'sdk.iad-03.braze.com',
     '04': 'sdk.iad-04.braze.com',
+    '05': 'sdk.iad-05.braze.com',
     '06': 'sdk.iad-06.braze.com',
     '08': 'sdk.iad-08.braze.com',
     EU: 'sdk.fra-01.braze.eu',
+    EU02: 'sdk.fra-02.braze.eu'
 };
 
 var constructor = function() {


### PR DESCRIPTION
Added in the info from braze for new servers

note: syntax highlighting for "EU" string started to fail for me once there was a comma after the EU line. I left it how it was before, but still not highlighting so I am thinking I have a bad quote or something?

# Summary

Braze has asked that we add these servers to our server list wherever possible. 
