### PR TITLE
feat!: update Braze SDK to 3.5.0

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,6 +2,9 @@
     "env": {
         "browser": true
     },
+    "globals": {
+        "appboy": true
+    },
     "extends": ["plugin:prettier/recommended", "eslint:recommended"],
     "rules": {
         "indent": [
@@ -38,6 +41,6 @@
             "as-needed",
             { "keywords": false, "unnecessary": true, "numbers": false }
         ],
-        "no-multi-spaces": "error",
+        "no-multi-spaces": "error"
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,11 @@
         "regenerator-runtime": "^0.13.2"
       }
     },
+    "@braze/web-sdk": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@braze/web-sdk/-/web-sdk-3.5.0.tgz",
+      "integrity": "sha512-c2oA/1WdNzUP0n7APHVxJtMXneJIJlkDLw2rxr5wIn9qTfE9lKx0Il8pljjB5GcUZ1vwtkLW4Pf7WS4d+iBvkw=="
+    },
     "@mparticle/web-sdk": {
       "version": "2.11.3",
       "resolved": "https://registry.npmjs.org/@mparticle/web-sdk/-/web-sdk-2.11.3.tgz",
@@ -130,11 +135,6 @@
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
       }
-    },
-    "appboy-web-sdk": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/appboy-web-sdk/-/appboy-web-sdk-2.5.2.tgz",
-      "integrity": "sha512-Gh5yAgEH/N7Wc3A0Pm8wZNb7uTygdHCB2BiJlI/0HZbJ1iWiA5SjGplTjovPZtrJK22AGcqRp9XVtea3EBYC9w=="
     },
     "arr-diff": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
         "watchify": "^3.11.1"
     },
     "dependencies": {
-        "@mparticle/web-sdk": "^2.11.3",
-        "appboy-web-sdk": "2.5.2"
+        "@braze/web-sdk": "^3.5.0",
+        "@mparticle/web-sdk": "^2.11.3"
     },
     "license": "Apache-2.0"
 }

--- a/src/AppboyKit-dev.js
+++ b/src/AppboyKit-dev.js
@@ -358,16 +358,7 @@ var constructor = function() {
         }
     }
 
-    function initForwarder(
-        settings,
-        service,
-        testMode,
-        trackerId,
-        userAttributes,
-        userIdentities,
-        appVersion,
-        appName
-    ) {
+    function initForwarder(settings, service, testMode) {
         // eslint-disable-line no-unused-vars
         try {
             forwarderSettings = settings;
@@ -405,13 +396,11 @@ var constructor = function() {
             }
 
             if (testMode !== true) {
-                /* eslint-disable */
                 appboy.initialize(forwarderSettings.apiKey, options);
+                appboy.addSdkMetadata(['mp']);
 
                 primeAppBoyWebPush();
                 openSession(forwarderSettings);
-
-                /* eslint-enable */
             } else {
                 if (!appboy.initialize(forwarderSettings.apiKey, options)) {
                     return 'Failed to initialize: ' + name;

--- a/src/AppboyKit-dev.js
+++ b/src/AppboyKit-dev.js
@@ -352,7 +352,9 @@ var constructor = function() {
 
     function openSession(forwarderSettings) {
         appboy.openSession();
-        appboy.logCustomEvent(forwarderSettings.softPushCustomEventName);
+        if (forwarderSettings.softPushCustomEventName) {
+            appboy.logCustomEvent(forwarderSettings.softPushCustomEventName);
+        }
     }
 
     function initForwarder(

--- a/src/AppboyKit-dev.js
+++ b/src/AppboyKit-dev.js
@@ -312,55 +312,44 @@ var constructor = function() {
     }
 
     function primeAppBoyWebPush() {
-                                      // The following code block is Braze's best practice for implementing
-                                      // their push primer.  It should not be changed unless Braze updates it
-                                      // https://www.braze.com/docs/developer_guide/platform_integration_guides/web/push_notifications/integration/#soft-push-prompts
-                                      appboy.subscribeToInAppMessage(function(
-                                          inAppMessage
-                                      ) {
-                                          var shouldDisplay = true;
+        // The following code block is Braze's best practice for implementing
+        // their push primer.  It should not be changed unless Braze updates it
+        // https://www.braze.com/docs/developer_guide/platform_integration_guides/web/push_notifications/integration/#soft-push-prompts
+        appboy.subscribeToInAppMessage(function(inAppMessage) {
+            var shouldDisplay = true;
 
-                                          if (
-                                              inAppMessage instanceof
-                                              appboy.InAppMessage
-                                          ) {
-                                              // Read the key-value pair for msg-id
-                                              var msgId =
-                                                  inAppMessage.extras['msg-id'];
+            if (inAppMessage instanceof appboy.InAppMessage) {
+                // Read the key-value pair for msg-id
+                var msgId = inAppMessage.extras['msg-id'];
 
-                                              // If this is our push primer message
-                                              if (msgId == 'push-primer') {
-                                                  // We don't want to display the soft push prompt to users on browsers that don't support push, or if the user
-                                                  // has already granted/blocked permission
-                                                  if (
-                                                      !appboy.isPushSupported() ||
-                                                      appboy.isPushPermissionGranted() ||
-                                                      appboy.isPushBlocked()
-                                                  ) {
-                                                      shouldDisplay = false;
-                                                  }
-                                                  if (
-                                                      inAppMessage.buttons[0] !=
-                                                      null
-                                                  ) {
-                                                      // Prompt the user when the first button is clicked
-                                                      inAppMessage.buttons[0].subscribeToClickedEvent(
-                                                          function() {
-                                                              appboy.registerAppboyPushMessages();
-                                                          }
-                                                      );
-                                                  }
-                                              }
-                                          }
+                // If this is our push primer message
+                if (msgId == 'push-primer') {
+                    // We don't want to display the soft push prompt to users on browsers that don't support push, or if the user
+                    // has already granted/blocked permission
+                    if (
+                        !appboy.isPushSupported() ||
+                        appboy.isPushPermissionGranted() ||
+                        appboy.isPushBlocked()
+                    ) {
+                        shouldDisplay = false;
+                    }
+                    if (inAppMessage.buttons[0] != null) {
+                        // Prompt the user when the first button is clicked
+                        inAppMessage.buttons[0].subscribeToClickedEvent(
+                            function() {
+                                appboy.registerAppboyPushMessages();
+                            }
+                        );
+                    }
+                }
+            }
 
-                                          // Display the message
-                                          if (shouldDisplay) {
-                                              appboy.display.showInAppMessage(
-                                                  inAppMessage
-                                              );
-                                          }
-                                      });
-                                  }
+            // Display the message
+            if (shouldDisplay) {
+                appboy.display.showInAppMessage(inAppMessage);
+            }
+        });
+    }
 
     function openSession(forwarderSettings) {
         appboy.openSession();

--- a/src/AppboyKit-dev.js
+++ b/src/AppboyKit-dev.js
@@ -312,6 +312,8 @@ var constructor = function() {
     }
 
     function primeAppBoyWebPush() {
+        // Per Braze push notification documentation
+        // https://www.braze.com/docs/developer_guide/platform_integration_guides/web/push_notifications/integration/#soft-push-prompts
         appboy.subscribeToInAppMessage(function(inAppMessage) {
             var shouldDisplay = true;
 

--- a/src/AppboyKit-dev.js
+++ b/src/AppboyKit-dev.js
@@ -394,20 +394,14 @@ var constructor = function() {
                     options.baseUrl = customUrl;
                 }
             }
-
             if (testMode !== true) {
                 appboy.initialize(forwarderSettings.apiKey, options);
-                appboy.addSdkMetadata(['mp']);
-
-                primeAppBoyWebPush();
-                openSession(forwarderSettings);
+                finishAppboyInitialization(forwarderSettings);
             } else {
                 if (!appboy.initialize(forwarderSettings.apiKey, options)) {
                     return 'Failed to initialize: ' + name;
                 }
-
-                primeAppBoyWebPush();
-                openSession(forwarderSettings);
+                finishAppboyInitialization(forwarderSettings);
             }
             return 'Successfully initialized: ' + name;
         } catch (e) {
@@ -416,6 +410,13 @@ var constructor = function() {
             );
         }
     }
+
+    function finishAppboyInitialization(forwarderSettings) {
+        appboy.addSdkMetadata(['mp']);
+        primeAppBoyWebPush();
+        openSession(forwarderSettings);
+    }
+
     /**************************/
     /** End mParticle API **/
     /**************************/

--- a/src/AppboyKit-dev.js
+++ b/src/AppboyKit-dev.js
@@ -215,7 +215,6 @@ var constructor = function() {
                 event
             );
             if (listOfPageEvents != null) {
-                debugger;
                 for (var i = 0; i < listOfPageEvents.length; i++) {
                     // finalLoopResult keeps track of if any logAppBoyEvent in this loop returns true or not
                     var finalLoopResult = false;
@@ -306,7 +305,6 @@ var constructor = function() {
         }
 
         appboy.changeUser(appboyUserIDType);
-        debugger;
 
         if (userIdentities.email) {
             appboy.getUser().setEmail(userIdentities.email);
@@ -318,7 +316,6 @@ var constructor = function() {
             var shouldDisplay = true;
 
             if (inAppMessage instanceof appboy.InAppMessage) {
-                debugger;
                 // Read the key-value pair for msg-id
                 var msgId = inAppMessage.extras['msg-id'];
 
@@ -346,7 +343,6 @@ var constructor = function() {
 
             // Display the message
             if (shouldDisplay) {
-                debugger;
                 appboy.display.showInAppMessage(inAppMessage);
             }
         });

--- a/src/AppboyKit-dev.js
+++ b/src/AppboyKit-dev.js
@@ -312,43 +312,55 @@ var constructor = function() {
     }
 
     function primeAppBoyWebPush() {
-        // Per Braze push notification documentation
-        // https://www.braze.com/docs/developer_guide/platform_integration_guides/web/push_notifications/integration/#soft-push-prompts
-        appboy.subscribeToInAppMessage(function(inAppMessage) {
-            var shouldDisplay = true;
+                                      // The following code block is Braze's best practice for implementing
+                                      // their push primer.  It should not be changed unless Braze updates it
+                                      // https://www.braze.com/docs/developer_guide/platform_integration_guides/web/push_notifications/integration/#soft-push-prompts
+                                      appboy.subscribeToInAppMessage(function(
+                                          inAppMessage
+                                      ) {
+                                          var shouldDisplay = true;
 
-            if (inAppMessage instanceof appboy.InAppMessage) {
-                // Read the key-value pair for msg-id
-                var msgId = inAppMessage.extras['msg-id'];
+                                          if (
+                                              inAppMessage instanceof
+                                              appboy.InAppMessage
+                                          ) {
+                                              // Read the key-value pair for msg-id
+                                              var msgId =
+                                                  inAppMessage.extras['msg-id'];
 
-                // If this is our push primer message
-                if (msgId == 'push-primer') {
-                    // We don't want to display the soft push prompt to users on browsers that don't support push, or if the user
-                    // has already granted/blocked permission
-                    if (
-                        !appboy.isPushSupported() ||
-                        appboy.isPushPermissionGranted() ||
-                        appboy.isPushBlocked()
-                    ) {
-                        shouldDisplay = false;
-                    }
-                    if (inAppMessage.buttons[0] != null) {
-                        // Prompt the user when the first button is clicked
-                        inAppMessage.buttons[0].subscribeToClickedEvent(
-                            function() {
-                                appboy.registerAppboyPushMessages();
-                            }
-                        );
-                    }
-                }
-            }
+                                              // If this is our push primer message
+                                              if (msgId == 'push-primer') {
+                                                  // We don't want to display the soft push prompt to users on browsers that don't support push, or if the user
+                                                  // has already granted/blocked permission
+                                                  if (
+                                                      !appboy.isPushSupported() ||
+                                                      appboy.isPushPermissionGranted() ||
+                                                      appboy.isPushBlocked()
+                                                  ) {
+                                                      shouldDisplay = false;
+                                                  }
+                                                  if (
+                                                      inAppMessage.buttons[0] !=
+                                                      null
+                                                  ) {
+                                                      // Prompt the user when the first button is clicked
+                                                      inAppMessage.buttons[0].subscribeToClickedEvent(
+                                                          function() {
+                                                              appboy.registerAppboyPushMessages();
+                                                          }
+                                                      );
+                                                  }
+                                              }
+                                          }
 
-            // Display the message
-            if (shouldDisplay) {
-                appboy.display.showInAppMessage(inAppMessage);
-            }
-        });
-    }
+                                          // Display the message
+                                          if (shouldDisplay) {
+                                              appboy.display.showInAppMessage(
+                                                  inAppMessage
+                                              );
+                                          }
+                                      });
+                                  }
 
     function openSession(forwarderSettings) {
         appboy.openSession();

--- a/test/index.html
+++ b/test/index.html
@@ -21,7 +21,7 @@
 
         window.mParticle = new mp();
     </script>
-    <script src="../AppboyKit.js" data-cover></script>
+    <script src="../dist/AppboyKit.iife.js" data-cover></script>
 
     <script>mocha.setup('bdd')</script>
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -65,12 +65,6 @@ describe('Appboy Forwarder', function() {
         },
         MockDisplay = function() {
             var self = this;
-
-            this.automaticallyShowNewInAppMessagesCalled = false;
-
-            this.automaticallyShowNewInAppMessages = function() {
-                self.automaticallyShowNewInAppMessagesCalled = true;
-            };
         },
         MockAppboyUser = function() {
             var self = this;
@@ -165,12 +159,20 @@ describe('Appboy Forwarder', function() {
             this.baseUrl = null;
             this.userId = null;
             this.doNotLoadFontAwesome = null;
-
+            this.metadata = null;
+            this.subscribeToInAppMessageCalled = false;
             this.eventProperties = [];
             this.purchaseEventProperties = [];
 
             this.user = new MockAppboyUser();
             this.display = new MockDisplay();
+            this.addSdkMetadata = function(metadata) {
+                self.metadata = metadata;
+            };
+
+            this.subscribeToInAppMessage = function() {
+                self.subscribeToInAppMessageCalled = true;
+            };
 
             this.initialize = function(apiKey, options) {
                 self.initializeCalled = true;
@@ -182,7 +184,6 @@ describe('Appboy Forwarder', function() {
 
             this.openSession = function(func) {
                 self.openSessionCalled = true;
-                func();
             };
 
             this.changeUser = function(id) {
@@ -278,20 +279,17 @@ describe('Appboy Forwarder', function() {
         );
     });
 
-    it('should initialize with apiKey', function() {
+    it('should initialize with apiKey and mp metadata', function() {
         window.appboy.should.have.property('apiKey', '123456');
+        window.appboy.should.have.property('metadata', ['mp']);
     });
 
     it('should open a new session and refresh in app messages upon initialization', function() {
         window.appboy.should.have.property('initializeCalled', true);
         window.appboy.should.have.property('openSessionCalled', true);
         window.appboy.should.have.property(
-            'subscribeToNewInAppMessagesCalled',
+            'subscribeToInAppMessageCalled',
             true
-        );
-        window.appboy.display.should.have.property(
-            'automaticallyShowNewInAppMessagesCalled',
-            false
         );
     });
 


### PR DESCRIPTION
# Summary

This PR updates the Braze SDK to 3.5.0, which includes breaking changes from Braze's end.

Due to these [breaking changes](https://www.braze.com/docs/developer_guide/platform_integration_guides/web/changelog/#300), we are sending customer comms to ensure our customers are aware of what they have to do if they are using any Braze SDK methods directly.  We will not release this until ~60 days after customer comms have been made available to give customers time to address any potential breaking changes in their code.

NPM customers can get this right away, but CDN customers will need to wait those 60 days to ensure all customers have the time to make the necessary changes so their code doesn't break.