### PR TITLE
Adding contentSecurityNonce option to settings

### DIFF
--- a/src/AppboyKit-dev.js
+++ b/src/AppboyKit-dev.js
@@ -416,6 +416,11 @@ var constructor = function() {
                 if (customUrl) {
                     options.baseUrl = customUrl;
                 }
+            } 
+            
+            if (forwarderSettings.contentSecurityNonce) {
+                options.contentSecurityNonce =
+                    forwarderSettings.contentSecurityNonce;
             }
 
             if (testMode !== true) {


### PR DESCRIPTION
# Summary

Allows to set the nonce value in the Braze event connection settings. That value will be passed to the contentSecurityNonce initialization option to propagate it to newly created scripts and styles generated by the Braze SDK - https://www.braze.com/docs/developer_guide/platform_integration_guides/web/content_security_policy/#nonce
