### PR TITLE
Adding customFlags API parameter

### DIFF
--- a/src/AppboyKit-dev.js
+++ b/src/AppboyKit-dev.js
@@ -421,9 +421,10 @@ var constructor = function() {
                 }
             }
 
-            if (mpCustomFlags && mpCustomFlags['APPBOY']) {
-                for (var key in mpCustomFlags.APPBOY) {
-                    options[key] = mpCustomFlags.APPBOY[key]
+            if (mpCustomFlags && mpCustomFlags[moduleId]) {
+                var brazeFlags = mpCustomFlags[moduleId];
+                if (typeof brazeFlags.initOptions == 'function') {
+                    brazeFlags.initOptions(options)
                 }
             }
             

--- a/src/AppboyKit-dev.js
+++ b/src/AppboyKit-dev.js
@@ -421,9 +421,9 @@ var constructor = function() {
                 }
             }
 
-            if (mpCustomFlags && mpCustomFlags[moduleId]) {
-                var brazeFlags = mpCustomFlags[moduleId];
-                if (typeof brazeFlags.initOptions == 'function') {
+            if (mpCustomFlags && mpCustomFlags[moduleId.toString()]) {
+                var brazeFlags = mpCustomFlags[moduleId.toString()];
+                if (typeof brazeFlags.initOptions === 'function') {
                     brazeFlags.initOptions(options)
                 }
             }

--- a/src/AppboyKit-dev.js
+++ b/src/AppboyKit-dev.js
@@ -423,11 +423,12 @@ var constructor = function() {
 
             if (mpCustomFlags && mpCustomFlags[moduleId.toString()]) {
                 var brazeFlags = mpCustomFlags[moduleId.toString()];
+
                 if (typeof brazeFlags.initOptions === 'function') {
-                    brazeFlags.initOptions(options)
+                    brazeFlags.initOptions(options);
                 }
             }
-            
+
             if (testMode !== true) {
                 /* eslint-disable */
                 appboy.initialize(forwarderSettings.apiKey, options);

--- a/src/AppboyKit-dev.js
+++ b/src/AppboyKit-dev.js
@@ -39,7 +39,8 @@ var constructor = function() {
     var self = this,
         forwarderSettings,
         options = {},
-        reportingService;
+        reportingService,
+        mpCustomFlags;
 
     self.name = name;
 
@@ -377,12 +378,14 @@ var constructor = function() {
         userAttributes,
         userIdentities,
         appVersion,
-        appName
+        appName,
+        customFlags
     ) {
         console.warn(
             'mParticle is upgrading the Braze web kit that you are currently using on 6/8/2022.  You will automatically receive this update if implementing mParticle via snippet/CDN.  There may be breaking changes if you invoke deprecated Braze SDK methods. Please see https://docs.mparticle.com/integrations/braze/event for more information.'
         );
         // eslint-disable-line no-unused-vars
+        mpCustomFlags = customFlags;
         try {
             forwarderSettings = settings;
             reportingService = service;
@@ -418,6 +421,12 @@ var constructor = function() {
                 }
             }
 
+            if (mpCustomFlags && mpCustomFlags['APPBOY']) {
+                for (var key in mpCustomFlags.APPBOY) {
+                    options[key] = mpCustomFlags.APPBOY[key]
+                }
+            }
+            
             if (testMode !== true) {
                 /* eslint-disable */
                 appboy.initialize(forwarderSettings.apiKey, options);

--- a/test/tests.js
+++ b/test/tests.js
@@ -173,6 +173,7 @@ describe('Appboy Forwarder', function() {
             this.display = new MockDisplay();
 
             this.initialize = function(apiKey, options) {
+                self.options = options;
                 self.initializeCalled = true;
                 self.apiKey = apiKey;
                 self.baseUrl = options.baseUrl || null;
@@ -1266,5 +1267,33 @@ describe('Appboy Forwarder', function() {
         });
 
         window.appboy.should.have.property('doNotLoadFontAwesome', false);
+    });
+
+    it('should add additional braze settings passed from custom flags to the options object', function() {
+        window.appboy = new MockAppboy();
+        mParticle.forwarder.init(
+            {
+                doNotLoadFontAwesome: null,
+                apiKey: 'test',
+            },
+            null,
+            true,
+            null,
+            null,
+            null,
+            null,
+            null,
+            {
+                28: {
+                    initOptions: function(options) {
+                        options.brazeSetting1 = true;
+                        options.brazeSetting2 = true;
+                    },
+                },
+            }
+        );
+
+        window.appboy.options.should.have.property('brazeSetting1', true);
+        window.appboy.options.should.have.property('brazeSetting2', true);
     });
 });


### PR DESCRIPTION
# Summary

Adding the customFlags parameter that allows to expose an API to pass any optional initialization parameters to the Appboy/Braze web SDK.
